### PR TITLE
refactors the same window info logic into react hooks

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,6 +20,7 @@ module.exports = {
   },
   plugins: [
     'react',
+    'react-hooks',
   ],
   rules: {
     "react/jsx-filename-extension": [1, { "extensions": [".js", ".jsx"] }],
@@ -38,6 +39,8 @@ module.exports = {
     "import/prefer-default-export": 0,
     "no-throw-literal": 0,
     "react/jsx-max-props-per-line": [1, { "maximum": 1 }],
-    "import/no-extraneous-dependencies": ["error", {"devDependencies": true}],
+    "import/no-extraneous-dependencies": ["error", { "devDependencies": true }],
+    "react-hooks/rules-of-hooks": "error",
+    "react-hooks/exhaustive-deps": "warn",
   },
 };

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "react": "^16.8.0"
   },
   "dependencies": {
+    "eslint-plugin-react-hooks": "^2.3.0",
     "prop-types": "^15.7.2",
     "react": "^16.11.0",
     "react-dom": "^16.11.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2258,6 +2258,11 @@ eslint-plugin-jsx-a11y@^6.2.1:
     has "^1.0.3"
     jsx-ast-utils "^2.2.1"
 
+eslint-plugin-react-hooks@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-2.3.0.tgz#53e073961f1f5ccf8dd19558036c1fac8c29d99a"
+  integrity sha512-gLKCa52G4ee7uXzdLiorca7JIQZPPXRAQDXV83J4bUEeUuc5pIEyZYAZ45Xnxe5IuupxEqHS+hUhSLIimK1EMw==
+
 eslint-plugin-react@^7.12.4:
   version "7.16.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.16.0.tgz#9928e4f3e2122ed3ba6a5b56d0303ba3e41d8c09"


### PR DESCRIPTION
Refactors the Provider to use hooks instead of classes. 
Also added the hooks [dependency checker](https://reactjs.org/docs/hooks-rules.html#eslint-plugin)

Take a look, not a priority PR, just something that might be nice.