### PR TITLE
chore: adds use client directive

### DIFF
--- a/src/WindowInfo/index.tsx
+++ b/src/WindowInfo/index.tsx
@@ -1,3 +1,4 @@
+'use client'
 import React, { Fragment } from 'react';
 import useWindowInfo from '../useWindowInfo';
 import { IWindowInfoContext } from '../WindowInfoProvider/context';

--- a/src/WindowInfoProvider/context.tsx
+++ b/src/WindowInfoProvider/context.tsx
@@ -1,3 +1,4 @@
+'use client'
 import { createContext } from 'react';
 
 export type WatchedBreakpoints = {

--- a/src/WindowInfoProvider/index.tsx
+++ b/src/WindowInfoProvider/index.tsx
@@ -1,3 +1,4 @@
+'use client'
 import React, { useCallback, useEffect, useReducer, useRef } from 'react';
 import WindowInfoContext, { IWindowInfoContext } from '../WindowInfoProvider/context';
 

--- a/src/useWindowInfo/index.tsx
+++ b/src/useWindowInfo/index.tsx
@@ -1,3 +1,4 @@
+'use client'
 import { useContext } from 'react';
 import WindowInfoContext, { IWindowInfoContext } from '../WindowInfoProvider/context';
 

--- a/src/withWindowInfo/index.tsx
+++ b/src/withWindowInfo/index.tsx
@@ -1,3 +1,4 @@
+'use client'
 import React from 'react';
 import useWindowInfo from '../useWindowInfo';
 


### PR DESCRIPTION
Adds the `use client` directive to all components so that they can be directly imported into React Server Components.