### PR TITLE
chore: adds license info to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@faceless-ui/window-info",
   "version": "3.0.0-beta.0",
+  "license": "MIT",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
License metadata helps with automated tooling to credit open source projects and comply with attribution requirements.